### PR TITLE
Separate TransactionType to new file

### DIFF
--- a/pkg/core/transaction.go
+++ b/pkg/core/transaction.go
@@ -5,31 +5,9 @@ import (
 	"io"
 )
 
-// TransactionType is the type of a transaction.
-type TransactionType uint8
-
-// String implements the stringer interface.
-func (t TransactionType) String() string {
-	switch t {
-	case MinerTX:
-		return "miner transaction"
-	case IssueTX:
-		return "issue transaction"
-	case ClaimTX:
-		return "claim transaction"
-	case EnrollmentTX:
-		return "enrollment transaction"
-	case VotingTX:
-		return "voting transaction"
-	case RegisterTX:
-		return "register transaction"
-	case ContractTX:
-		return "contract transaction"
-	case AgencyTX:
-		return "agency transaction"
-	default:
-		return ""
-	}
+// Transaction is a process recorded in the NEO system.
+type Transaction struct {
+	Type TransactionType
 }
 
 // All processes in NEO system are recorded in transactions.
@@ -45,18 +23,13 @@ const (
 	AgencyTX                     = 0xb0
 )
 
-// Transaction is a process recorded in the NEO system.
-type Transaction struct {
-	Type TransactionType
-}
-
 // DecodeBinary implements the payload interface.
-func (t *Transaction) DecodeBinary(r io.Reader) error {
+func (t Transaction) DecodeBinary(r io.Reader) error {
 	err := binary.Read(r, binary.LittleEndian, &t.Type)
 	return err
 }
 
 // EncodeBinary implements the payload interface.
-func (t *Transaction) EncodeBinary(w io.Writer) error {
+func (t Transaction) EncodeBinary(w io.Writer) error {
 	return nil
 }

--- a/pkg/core/transaction_type.go
+++ b/pkg/core/transaction_type.go
@@ -1,0 +1,28 @@
+package core
+
+// TransactionType is the type of a transaction.
+type TransactionType uint8
+
+// String implements the stringer interface.
+func (t TransactionType) String() string {
+	switch t {
+	case MinerTX:
+		return "miner transaction"
+	case IssueTX:
+		return "issue transaction"
+	case ClaimTX:
+		return "claim transaction"
+	case EnrollmentTX:
+		return "enrollment transaction"
+	case VotingTX:
+		return "voting transaction"
+	case RegisterTX:
+		return "register transaction"
+	case ContractTX:
+		return "contract transaction"
+	case AgencyTX:
+		return "agency transaction"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
### Problem

Walking through the repo to get up to speed and noticed that the `core/transaction.go` file had two types in it.

### Solution

Move the `TransactionType` struct to an individual file to increase readability. 

### Notes

- None