### PR TITLE
Added <=16 as the upper bound is inclusive

### DIFF
--- a/pkg/vm/emit.go
+++ b/pkg/vm/emit.go
@@ -40,7 +40,7 @@ func EmitInt(w *bytes.Buffer, i int64) error {
 	if i == 0 {
 		return EmitOpcode(w, Opushf)
 	}
-	if i > 0 && i < 16 {
+	if i > 0 && i <= 16 {
 		val := Opcode((int(Opush1) - 1 + int(i)))
 		return EmitOpcode(w, val)
 	}


### PR DESCRIPTION
### Problem

Not sure it was an actual problem, however the upper bound was inclusive.
### Solution

Added <= 

### Notes

Use [semver](https://semver.org/) to bump `VERSION`, and remember to run the following after
merging your PR:

```
make push-tag
```