### PR TITLE
Function to get private key from ASN.1 serialized structure

### DIFF
--- a/pkg/wallet/private_key.go
+++ b/pkg/wallet/private_key.go
@@ -58,7 +58,7 @@ func NewPrivateKeyFromBytes(b []byte) (*PrivateKey, error) {
 	return &PrivateKey{b}, nil
 }
 
-// NewPrivateKeyFromRawBytes returns a NEO PrivateKey from the protobuf serialized x509 private key.
+// NewPrivateKeyFromRawBytes returns a NEO PrivateKey from the ASN.1 serialized keys.
 func NewPrivateKeyFromRawBytes(b []byte) (*PrivateKey, error) {
 	privkey, err := x509.ParseECPrivateKey(b)
 	if err != nil {

--- a/pkg/wallet/private_key.go
+++ b/pkg/wallet/private_key.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -55,6 +56,19 @@ func NewPrivateKeyFromBytes(b []byte) (*PrivateKey, error) {
 		)
 	}
 	return &PrivateKey{b}, nil
+}
+
+// NewPrivateKeyFromRawBytes returns a NEO PrivateKey from the protobuf serialized x509 private key.
+func NewPrivateKeyFromRawBytes(b []byte) (*PrivateKey, error) {
+	privkey, err := x509.ParseECPrivateKey(b)
+	if err != nil {
+		return nil, err
+	}
+	pkw, err := NewPrivateKeyFromBytes(privkey.D.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return pkw, nil
 }
 
 // PublicKey derives the public key from the private key.


### PR DESCRIPTION
### Problem

I need to create private key from structure serialized as ASN.1  (containing public and private keys and some meta information). Such a key format is obtained with a standard go x509 lib using [this function](https://golang.org/pkg/crypto/x509/#MarshalECPrivateKey).
 For now, it is only possible to make PK from hex string of bytes.

### Solution

A function that converts ASN.1 serialized keys into the inner private key representation.

### Notes

Use [semver](https://semver.org/) to bump `VERSION`, and remember to run the following after
merging your PR:

```
make push-tag
```