### PR TITLE
make State a set as in reference C# implementation

### DIFF
--- a/pkg/rpc/types.go
+++ b/pkg/rpc/types.go
@@ -1,6 +1,9 @@
 package rpc
 
-import "github.com/CityOfZion/neo-go/pkg/core/transaction"
+import (
+	"github.com/CityOfZion/neo-go/pkg/core/transaction"
+	"github.com/CityOfZion/neo-go/pkg/vm"
+)
 
 type InvokeScriptResponse struct {
 	responseHeader
@@ -11,9 +14,9 @@ type InvokeScriptResponse struct {
 // InvokeResult represents the outcome of a script that is
 // executed by the NEO VM.
 type InvokeResult struct {
-	State       string `json:"state"`
-	GasConsumed string `json:"gas_consumed"`
-	Script      string `json:"script"`
+	State       vm.State `json:"state"`
+	GasConsumed string   `json:"gas_consumed"`
+	Script      string   `json:"script"`
 	Stack       []StackParam
 }
 

--- a/pkg/vm/state.go
+++ b/pkg/vm/state.go
@@ -1,25 +1,75 @@
 package vm
 
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
 // State of the VM.
 type State uint
 
 // Available States.
 const (
-	noneState State = iota
-	haltState
+	noneState State = 0
+	haltState State = 1 << iota
 	faultState
 	breakState
 )
 
+func (s State) HasFlag(f State) bool {
+	return s&f != 0
+}
+
 func (s State) String() string {
-	switch s {
-	case haltState:
-		return "HALT"
-	case faultState:
-		return "FAULT"
-	case breakState:
-		return "BREAK"
-	default:
+	if s == noneState {
 		return "NONE"
 	}
+
+	ss := make([]string, 0, 3)
+	if s.HasFlag(haltState) {
+		ss = append(ss, "HALT")
+	}
+	if s.HasFlag(faultState) {
+		ss = append(ss, "FAULT")
+	}
+	if s.HasFlag(breakState) {
+		ss = append(ss, "BREAK")
+	}
+	return strings.Join(ss, ", ")
+}
+
+func StateFromString(s string) (st State, err error) {
+	if s = strings.TrimSpace(s); s == "NONE" {
+		return noneState, nil
+	}
+
+	ss := strings.Split(s, ",")
+	for _, state := range ss {
+		switch state = strings.TrimSpace(state); state {
+		case "HALT":
+			st |= haltState
+		case "FAULT":
+			st |= faultState
+		case "BREAK":
+			st |= breakState
+		default:
+			return 0, errors.New("unknown state")
+		}
+	}
+	return
+}
+
+func (s State) MarshalJSON() (data []byte, err error) {
+	return []byte(s.String()), nil
+}
+
+func (s *State) UnmarshalJSON(data []byte) (err error) {
+	l := len(data)
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return errors.New("wrong format")
+	}
+
+	*s, err = StateFromString(string(data[1 : l-1]))
+	return
 }

--- a/pkg/vm/state.go
+++ b/pkg/vm/state.go
@@ -7,7 +7,7 @@ import (
 )
 
 // State of the VM.
-type State uint
+type State uint8
 
 // Available States.
 const (
@@ -61,7 +61,7 @@ func StateFromString(s string) (st State, err error) {
 }
 
 func (s State) MarshalJSON() (data []byte, err error) {
-	return []byte(s.String()), nil
+	return []byte(`"` + s.String() + `"`), nil
 }
 
 func (s *State) UnmarshalJSON(data []byte) (err error) {

--- a/pkg/vm/state_test.go
+++ b/pkg/vm/state_test.go
@@ -14,43 +14,58 @@ func TestStateFromString(t *testing.T) {
 	)
 
 	s, err = StateFromString("HALT")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, haltState, s)
 
 	s, err = StateFromString("BREAK")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, breakState, s)
 
 	s, err = StateFromString("FAULT")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, faultState, s)
 
 	s, err = StateFromString("NONE")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, noneState, s)
 
 	s, err = StateFromString("HALT, BREAK")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, haltState|breakState, s)
 
 	s, err = StateFromString("FAULT, BREAK")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, faultState|breakState, s)
 
 	s, err = StateFromString("HALT, KEK")
-	assert.NotEqual(t, nil, err)
+	assert.Error(t, err)
 }
 
 func TestState_HasFlag(t *testing.T) {
-	assert.Equal(t, true, haltState.HasFlag(haltState))
-	assert.Equal(t, true, breakState.HasFlag(breakState))
-	assert.Equal(t, true, faultState.HasFlag(faultState))
-	assert.Equal(t, true, (haltState | breakState).HasFlag(haltState))
-	assert.Equal(t, true, (haltState | breakState).HasFlag(breakState))
+	assert.True(t, haltState.HasFlag(haltState))
+	assert.True(t, breakState.HasFlag(breakState))
+	assert.True(t, faultState.HasFlag(faultState))
+	assert.True(t, (haltState | breakState).HasFlag(haltState))
+	assert.True(t, (haltState | breakState).HasFlag(breakState))
 
-	assert.Equal(t, false, haltState.HasFlag(breakState))
-	assert.Equal(t, false, noneState.HasFlag(haltState))
-	assert.Equal(t, false, (faultState | breakState).HasFlag(haltState))
+	assert.False(t, haltState.HasFlag(breakState))
+	assert.False(t, noneState.HasFlag(haltState))
+	assert.False(t, (faultState | breakState).HasFlag(haltState))
+}
+
+func TestState_MarshalJSON(t *testing.T) {
+	var (
+		data []byte
+		err  error
+	)
+
+	data, err = json.Marshal(haltState | breakState)
+	assert.NoError(t, err)
+	assert.Equal(t, data, []byte(`"HALT, BREAK"`))
+
+	data, err = json.Marshal(faultState)
+	assert.NoError(t, err)
+	assert.Equal(t, data, []byte(`"FAULT"`))
 }
 
 func TestState_UnmarshalJSON(t *testing.T) {
@@ -60,14 +75,14 @@ func TestState_UnmarshalJSON(t *testing.T) {
 	)
 
 	err = json.Unmarshal([]byte(`"HALT, BREAK"`), &s)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, haltState|breakState, s)
 
 	err = json.Unmarshal([]byte(`"FAULT, BREAK"`), &s)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, faultState|breakState, s)
 
 	err = json.Unmarshal([]byte(`"NONE"`), &s)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, noneState, s)
 }

--- a/pkg/vm/state_test.go
+++ b/pkg/vm/state_test.go
@@ -1,0 +1,73 @@
+package vm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateFromString(t *testing.T) {
+	var (
+		s   State
+		err error
+	)
+
+	s, err = StateFromString("HALT")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, haltState, s)
+
+	s, err = StateFromString("BREAK")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, breakState, s)
+
+	s, err = StateFromString("FAULT")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, faultState, s)
+
+	s, err = StateFromString("NONE")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, noneState, s)
+
+	s, err = StateFromString("HALT, BREAK")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, haltState|breakState, s)
+
+	s, err = StateFromString("FAULT, BREAK")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, faultState|breakState, s)
+
+	s, err = StateFromString("HALT, KEK")
+	assert.NotEqual(t, nil, err)
+}
+
+func TestState_HasFlag(t *testing.T) {
+	assert.Equal(t, true, haltState.HasFlag(haltState))
+	assert.Equal(t, true, breakState.HasFlag(breakState))
+	assert.Equal(t, true, faultState.HasFlag(faultState))
+	assert.Equal(t, true, (haltState | breakState).HasFlag(haltState))
+	assert.Equal(t, true, (haltState | breakState).HasFlag(breakState))
+
+	assert.Equal(t, false, haltState.HasFlag(breakState))
+	assert.Equal(t, false, noneState.HasFlag(haltState))
+	assert.Equal(t, false, (faultState | breakState).HasFlag(haltState))
+}
+
+func TestState_UnmarshalJSON(t *testing.T) {
+	var (
+		s   State
+		err error
+	)
+
+	err = json.Unmarshal([]byte(`"HALT, BREAK"`), &s)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, haltState|breakState, s)
+
+	err = json.Unmarshal([]byte(`"FAULT, BREAK"`), &s)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, faultState|breakState, s)
+
+	err = json.Unmarshal([]byte(`"NONE"`), &s)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, noneState, s)
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -194,7 +194,7 @@ func (v *VM) Run() {
 
 	v.state = noneState
 	for {
-		switch true {
+		switch {
 		case v.state.HasFlag(haltState):
 			if !v.mute {
 				fmt.Println(v.Stack("estack"))

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -194,21 +194,21 @@ func (v *VM) Run() {
 
 	v.state = noneState
 	for {
-		switch v.state {
-		case haltState:
+		switch true {
+		case v.state.HasFlag(haltState):
 			if !v.mute {
 				fmt.Println(v.Stack("estack"))
 			}
 			return
-		case breakState:
+		case v.state.HasFlag(breakState):
 			ctx := v.Context()
 			i, op := ctx.CurrInstr()
 			fmt.Printf("at breakpoint %d (%s)\n", i, op.String())
 			return
-		case faultState:
+		case v.state.HasFlag(faultState):
 			fmt.Println("FAULT")
 			return
-		case noneState:
+		case v.state == noneState:
 			v.Step()
 		}
 	}


### PR DESCRIPTION
### Problem

State of VM, returned from RPC-node can be "HALT, BREAK", i.e. in contain multiple states simultaneously. This is because in C# implementation, vm.State is actually a set (enum with flags)
https://github.com/neo-project/neo-vm/blob/79c3aada150865036617fc4a785dbfe618c2e3b7/src/neo-vm/VMState.cs

Right now we cant parse response into a single state.

### Solution

Make State a set with different flags ("NONE" means no flags).

All tests are passed, but I'm not sure if I've broken anything deep inside.
Let me know what you think.
