### PR TITLE
[Peer] Refactor

### DIFF
--- a/pkg/peer/config.go
+++ b/pkg/peer/config.go
@@ -14,34 +14,18 @@ type LocalConfig struct {
 	ProtocolVer protocol.Version
 	Relay       bool
 	Port        uint16
-	// pointer to config will keep the startheight updated for each version
-	//Message we plan to send
-	StartHeight  func() uint32
+
+	// pointer to config will keep the startheight updated
+	StartHeight func() uint32
+
+	// Response Handlers
 	OnHeader     func(*Peer, *payload.HeadersMessage)
-	OnGetHeaders func(msg *payload.GetHeadersMessage) // returns HeaderMessage
+	OnGetHeaders func(*Peer, *payload.GetHeadersMessage)
 	OnAddr       func(*Peer, *payload.AddrMessage)
 	OnGetAddr    func(*Peer, *payload.GetAddrMessage)
 	OnInv        func(*Peer, *payload.InvMessage)
-	OnGetData    func(msg *payload.GetDataMessage)
+	OnGetData    func(*Peer, *payload.GetDataMessage)
 	OnBlock      func(*Peer, *payload.BlockMessage)
-	OnGetBlocks  func(msg *payload.GetBlocksMessage)
+	OnGetBlocks  func(*Peer, *payload.GetBlocksMessage)
+	OnTx         func(*Peer, *payload.TXMessage)
 }
-
-// func DefaultConfig() LocalConfig {
-// 	return LocalConfig{
-// 		Net:         protocol.MainNet,
-// 		UserAgent:   "NEO-GO-Default",
-// 		Services:    protocol.NodePeerService,
-// 		Nonce:       1200,
-// 		ProtocolVer: 0,
-// 		Relay:       false,
-// 		Port:        10332,
-// 		// pointer to config will keep the startheight updated for each version
-// 		//Message we plan to send
-// 		StartHeight: DefaultHeight,
-// 	}
-// }
-
-// func DefaultHeight() uint32 {
-// 	return 10
-// }

--- a/pkg/peer/responsehandlers.go
+++ b/pkg/peer/responsehandlers.go
@@ -1,0 +1,111 @@
+package peer
+
+import (
+	"errors"
+	"time"
+
+	"github.com/CityOfZion/neo-go/pkg/wire/payload"
+)
+
+// OnGetData is called when a GetData message is received
+func (p *Peer) OnGetData(msg *payload.GetDataMessage) {
+	p.inch <- func() {
+		if p.config.OnInv != nil {
+			p.config.OnGetData(p, msg)
+		}
+	}
+}
+
+//OnTX is called when a TX message is received
+func (p *Peer) OnTX(msg *payload.TXMessage) {
+	p.inch <- func() {
+		p.inch <- func() {
+			if p.config.OnTx != nil {
+				p.config.OnTx(p, msg)
+			}
+		}
+	}
+}
+
+// OnInv is called when a Inv message is received
+func (p *Peer) OnInv(msg *payload.InvMessage) {
+	p.inch <- func() {
+		if p.config.OnInv != nil {
+			p.config.OnInv(p, msg)
+		}
+	}
+}
+
+// OnGetHeaders is called when a GetHeaders message is received
+func (p *Peer) OnGetHeaders(msg *payload.GetHeadersMessage) {
+	p.inch <- func() {
+		if p.config.OnGetHeaders != nil {
+			p.config.OnGetHeaders(p, msg)
+		}
+	}
+}
+
+// OnAddr is called when a Addr message is received
+func (p *Peer) OnAddr(msg *payload.AddrMessage) {
+	p.inch <- func() {
+		if p.config.OnAddr != nil {
+			p.config.OnAddr(p, msg)
+		}
+	}
+}
+
+// OnGetAddr is called when a GetAddr message is received
+func (p *Peer) OnGetAddr(msg *payload.GetAddrMessage) {
+	p.inch <- func() {
+		if p.config.OnGetAddr != nil {
+			p.config.OnGetAddr(p, msg)
+		}
+	}
+}
+
+// OnGetBlocks is called when a GetBlocks message is received
+func (p *Peer) OnGetBlocks(msg *payload.GetBlocksMessage) {
+	p.inch <- func() {
+		if p.config.OnGetBlocks != nil {
+			p.config.OnGetBlocks(p, msg)
+		}
+	}
+}
+
+// OnBlocks is called when a Blocks message is received
+func (p *Peer) OnBlocks(msg *payload.BlockMessage) {
+	p.Detector.RemoveMessage(msg.Command())
+	p.inch <- func() {
+		if p.config.OnBlock != nil {
+			p.config.OnBlock(p, msg)
+		}
+	}
+}
+
+// OnHeaders is called when a Headers message is received
+func (p *Peer) OnHeaders(msg *payload.HeadersMessage) {
+	p.Detector.RemoveMessage(msg.Command())
+	p.inch <- func() {
+		if p.config.OnHeader != nil {
+			p.config.OnHeader(p, msg)
+		}
+	}
+}
+
+// OnVersion Listener will be called
+// during the handshake, any error checking should be done here for the versionMessage.
+// This should only ever be called during the handshake. Any other place and the peer will disconnect.
+func (p *Peer) OnVersion(msg *payload.VersionMessage) error {
+	if msg.Nonce == p.config.Nonce {
+		p.conn.Close()
+		return errors.New("self connection, disconnecting Peer")
+	}
+	p.versionKnown = true
+	p.port = msg.Port
+	p.services = msg.Services
+	p.userAgent = string(msg.UserAgent)
+	p.createdAt = time.Now()
+	p.relay = msg.Relay
+	p.startHeight = msg.StartHeight
+	return nil
+}

--- a/pkg/peer/stall/stall.go
+++ b/pkg/peer/stall/stall.go
@@ -168,6 +168,8 @@ func (d *Detector) removeMessage(cmd command.Type) []command.Type {
 	case command.Verack:
 		// We will now expect a verack
 		cmds = append(cmds, cmd)
+	default:
+		cmds = append(cmds, cmd)
 	}
 	return cmds
 }

--- a/pkg/peer/stall/stall_test.go
+++ b/pkg/peer/stall/stall_test.go
@@ -22,7 +22,7 @@ func TestAddRemoveMessage(t *testing.T) {
 	assert.Equal(t, 1, len(mp))
 	assert.IsType(t, time.Time{}, mp[command.GetAddr])
 
-	d.RemoveMessage(command.GetAddr)
+	d.RemoveMessage(command.Addr)
 	mp = d.GetMessages()
 
 	assert.Equal(t, 0, len(mp))


### PR DESCRIPTION
- Closes #239 

- moved response handlers to their own functions

- removed DefaultConfig from LocalConfig file

- passed peer as a parameter to all response handlers

- added peer start height

- refactored NewPeer function to be more concise and clear

- removed empty lines at end of functions

- Added AddMessage/RemoveMessage for Detector in outgoing and ingoing
requests for Block and Headers